### PR TITLE
deref log id passed to cast logger impl

### DIFF
--- a/src/duct/logger/cast.clj
+++ b/src/duct/logger/cast.clj
@@ -16,7 +16,7 @@
              ::ns-str ns-str
              ::file   file
              ::line   line
-             ::id     id}]
+             ::id     @id}]
       (cond
         (instance? Throwable event)
         (f (merge m {:msg "Throwable" :ex event}))


### PR DESCRIPTION
I found that the logs emitted by `duct.logger.cast` contains munged delay objects in them, which is probably not the intended output:

```clojure
{:duct.logger.cast/level :report,
 :duct.logger.cast/ns-str "duct.server.http.jetty",
 :duct.logger.cast/file "duct/server/http/jetty.clj",
 :duct.logger.cast/line 13,
 :duct.logger.cast/id #delay[{:status :pending, :val nil} 0x7ee4352], ; <- HERE
 :msg ":duct.server.http.jetty/starting-server",
 :duct.logger.cast/data {:port 3000}}
```

This is because `id` passed to a duct logger impl is [something that is wrapped with delay](https://github.com/duct-framework/logger/blob/4bc70ca541b655b0eb4b74308a4c4e932c6f5233/src/duct/logger.clj#L16), so you need to deref it to get the actual value. You can confirm like the following what is actually being passed to the cast logger:

```clojure
(require '[datomic.ion.cast :as cast]
         '[duct.logger :as logger]
         'duct.logger.cast
         '[integrant.core :as ig])

(let [config {:duct.logger/cast {}}
      logger (:duct.logger/cast (ig/init config))
      spy (atom nil)]
  (with-redefs [cast/event (fn [& args] (reset! spy {:args args}))]
    (logger/log logger :info ::test {:foo 42})
    @spy)))

;=>
{:args
 ({:duct.logger.cast/level :info,
   :duct.logger.cast/id #object[clojure.lang.Delay 0x272ce069 {:status :pending, :val nil}], ; <- HERE
   :duct.logger.cast/data {:foo 42},
   ... })}]
```

This PR fixes the above issue by deref'ing `id` passed to the cast logger.